### PR TITLE
Implement menvcfg and menvcfgh CSR functions

### DIFF
--- a/src/register/menvcfg.rs
+++ b/src/register/menvcfg.rs
@@ -1,0 +1,107 @@
+//! menvcfg register
+
+use bit_field::BitField;
+
+/// menvcfg register
+#[derive(Clone, Copy, Debug)]
+pub struct Menvcfg {
+    bits: usize,
+}
+
+/// Cache Block Invalidate instruction Enable
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum CBIE {
+    IllegalInstruction = 0,
+    ExecutedFlush = 1,
+    Reserved = 2,
+    ExecutedInvalidate = 3,
+}
+
+impl Menvcfg {
+    /// Returns the contents of the register as raw bits
+    #[inline]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+
+    /// Fence of I/O implies Memory
+    #[inline]
+    pub fn fiom(&self) -> bool {
+        self.bits.get_bit(0)
+    }
+
+    /// Cache Block Invalidate instruction Enable
+    #[inline]
+    pub fn mpp(&self) -> CBIE {
+        match self.bits.get_bits(4..5) {
+            0b00 => CBIE::IllegalInstruction,
+            0b01 => CBIE::ExecutedFlush,
+            0b10 => CBIE::Reserved,
+            0b11 => CBIE::ExecutedInvalidate,
+            _ => unreachable!(),
+        }
+    }
+
+    /// Cache Block Clean and Flush instruction Enable
+    #[inline]
+    pub fn cbcfe(&self) -> bool {
+        self.bits.get_bit(6)
+    }
+
+    /// Cache Block Zero instruction Enable
+    #[inline]
+    pub fn cbze(&self) -> bool {
+        self.bits.get_bit(7)
+    }
+
+    /// PBMTE controls whether the Svpbmt extension is available for use in S-mode and G-stage
+    /// address translation
+    #[cfg(riscv64)]
+    #[inline]
+    pub fn pbmte(&self) -> bool {
+        self.bits.get_bit(62)
+    }
+
+    /// STimeCmp Enable
+    #[cfg(riscv64)]
+    #[inline]
+    pub fn stce(&self) -> bool {
+        self.bits.get_bit(63)
+    }
+}
+
+read_csr_as!(Menvcfg, 0x30A);
+write_csr!(0x30A);
+set!(0x30A);
+clear!(0x30A);
+
+set_clear_csr!(
+    /// Fence of I/O implies Memory
+    , set_fiom, clear_fiom, 1 << 0);
+
+/// Cache Block Invalidate instruction Enable
+#[inline]
+pub unsafe fn set_cbie(cbie: CBIE) {
+    let mut value = _read();
+    value.set_bits(4..5, cbie as usize);
+    _write(value);
+}
+
+set_clear_csr!(
+    /// Cache Block Clean and Flush instruction Enable
+    , set_cbcfe, clear_cbcfe, 6 << 0);
+
+set_clear_csr!(
+    /// Cache Block Zero instruction Enable
+    , set_cbze, clear_cbze, 7 << 0);
+
+#[cfg(riscv64)]
+set_clear_csr!(
+    /// PBMTE controls whether the Svpbmt extension is available for use in S-mode and G-stage
+    /// address translation
+    , set_pbmte, clear_pbmte, 1 << 62);
+
+#[cfg(riscv64)]
+set_clear_csr!(
+    /// STimeCmp Enable
+    , set_stce, clear_stce, 1 << 63);

--- a/src/register/menvcfg.rs
+++ b/src/register/menvcfg.rs
@@ -32,7 +32,7 @@ impl Menvcfg {
 
     /// Cache Block Invalidate instruction Enable
     #[inline]
-    pub fn mpp(&self) -> CBIE {
+    pub fn cbie(&self) -> CBIE {
         match self.bits.get_bits(4..5) {
             0b00 => CBIE::IllegalInstruction,
             0b01 => CBIE::ExecutedFlush,

--- a/src/register/menvcfgh.rs
+++ b/src/register/menvcfgh.rs
@@ -1,0 +1,57 @@
+//! menvcfgh register
+
+#[cfg(riscv32)]
+use bit_field::BitField;
+
+/// menvcfgh register
+#[derive(Clone, Copy, Debug)]
+pub struct Menvcfgh {
+    bits: usize,
+}
+
+impl Menvcfgh {
+    /// Returns the contents of the register as raw bits
+    #[inline]
+    pub fn bits(&self) -> usize {
+        self.bits
+    }
+
+    /// PBMTE controls whether the Svpbmt extension is available for use in S-mode and G-stage
+    /// address translation
+    #[cfg(riscv32)]
+    #[inline]
+    pub fn pbmte(&self) -> bool {
+        self.bits.get_bit(30)
+    }
+
+    /// STimeCmp Enable
+    #[cfg(riscv32)]
+    #[inline]
+    pub fn stce(&self) -> bool {
+        self.bits.get_bit(31)
+    }
+}
+
+/// Reads the CSR
+#[inline]
+pub fn read() -> Menvcfgh {
+    Menvcfgh {
+        bits: unsafe { _read() },
+    }
+}
+
+read_csr_rv32!(0x31A);
+write_csr_rv32!(0x31A);
+set!(0x31A);
+clear!(0x31A);
+
+#[cfg(riscv32)]
+set_clear_csr!(
+    /// PBMTE controls whether the Svpbmt extension is available for use in S-mode and G-stage
+    /// address translation
+    , set_pbmte, clear_pbmte, 1 << 30);
+
+#[cfg(riscv32)]
+set_clear_csr!(
+    /// STimeCmp Enable
+    , set_stce, clear_stce, 1 << 31);

--- a/src/register/mod.rs
+++ b/src/register/mod.rs
@@ -7,6 +7,7 @@
 //! - instreth
 //! - hpmcounter<3-31>h
 //! - mcycleh
+//! - menvcfgh
 //! - minstreth
 //! - mhpmcounter<3-31>h
 
@@ -81,6 +82,10 @@ pub mod mepc;
 pub mod mip;
 pub mod mscratch;
 pub mod mtval;
+
+// Machine Configuration
+pub mod menvcfg;
+pub mod menvcfgh;
 
 // Machine Protection and Translation
 mod pmpcfgx;


### PR DESCRIPTION
The CSRs menvcfg and menvcfgh are defined in the RISC-V Privileged Architecture version 1.11. The CSR menvcfgh is RV32-only, and contains the high 32 bits of menvcfg.

Some fields in menvcfg/menvcfgh are defined by extensions that are now ratified:

- The STCE field is defined in Sstc
- The CBZE field is defined in Zicboz
- The CBCFE and CBIE fields are defined in Zicbom