### PR TITLE
register: pmpaddrx: switch to using sizes one larger than usize

### DIFF
--- a/src/register/pmpaddrx.rs
+++ b/src/register/pmpaddrx.rs
@@ -13,15 +13,15 @@ pub type Addr = u64;
 
 impl PmpAddr {
     #[inline]
-    pub fn decode(&self, mode: Mode) -> (Addr, Option<NonZeroSize>) {
+    pub fn decode(&self, mode: Mode) -> (Option<Addr>, Option<NonZeroSize>) {
         let big_bits: Addr = self.bits as Addr;
         match mode {
-            Mode::OFF => (big_bits, None),
-            Mode::TOR => (big_bits << 2, None),
-            Mode::NA4 => (big_bits << 2, Some(4.try_into().unwrap())),
+            Mode::OFF => (None, None),
+            Mode::TOR => (Some(big_bits << 2), None),
+            Mode::NA4 => (Some(big_bits << 2), Some(4.try_into().unwrap())),
             Mode::NAPOT => {
                 let (addr, size) = Self::decode_napot(self.bits);
-                (addr, Some(size.try_into().unwrap()))
+                (Some(addr), Some(size.try_into().unwrap()))
             }
         }
     }

--- a/src/register/pmpaddrx.rs
+++ b/src/register/pmpaddrx.rs
@@ -1,19 +1,24 @@
 use crate::register::pmpcfgx::Mode;
 use bit_field::BitField;
-use core::num::NonZeroUsize;
+use core::num::NonZeroU64;
 
 #[derive(Copy, Clone, Debug)]
 pub struct PmpAddr {
     bits: usize,
 }
 
+pub type Size = u64;
+pub type NonZeroSize = NonZeroU64;
+pub type Addr = u64;
+
 impl PmpAddr {
     #[inline]
-    pub fn decode(&self, mode: Mode) -> (usize, Option<NonZeroUsize>) {
+    pub fn decode(&self, mode: Mode) -> (Addr, Option<NonZeroSize>) {
+        let big_bits: Addr = self.bits as Addr;
         match mode {
-            Mode::OFF => (self.bits, None),
-            Mode::TOR => (self.bits << 2, None),
-            Mode::NA4 => (self.bits << 2, None),
+            Mode::OFF => (big_bits, None),
+            Mode::TOR => (big_bits << 2, None),
+            Mode::NA4 => (big_bits << 2, None),
             Mode::NAPOT => {
                 let (addr, size) = Self::decode_napot(self.bits);
                 (addr, Some(size.try_into().unwrap()))
@@ -22,47 +27,48 @@ impl PmpAddr {
     }
 
     #[inline]
-    pub fn encode(&mut self, mode: Mode, addr: usize, size: Option<NonZeroUsize>) {
+    pub fn encode(&mut self, mode: Mode, addr: Addr, size: Option<NonZeroSize>) {
         self.bits = match mode {
             Mode::OFF => 0,
-            Mode::TOR => addr >> 2,
-            Mode::NA4 => addr >> 2,
+            Mode::TOR => (addr >> 2).try_into().unwrap(),
+            Mode::NA4 => (addr >> 2).try_into().unwrap(),
             Mode::NAPOT => Self::encode_napot(addr, size.unwrap().into()),
         }
     }
 
     #[inline]
-    fn encode_napot(addr: usize, size: usize) -> usize {
+    fn encode_napot(addr: Addr, size: Size) -> usize {
         // See riscv priv spec "Physical Memory Protection CSRs
         // "Each PMP address register encodes bits 33–2 of a 34-bit physical address for RV32"
         // and
         // "For RV64, each PMP address register encodes bits 55–2 of a 56-bit physical address"
-        // TODO: top bits will get lost on 64bit system
-        let addr = addr >> 2;
+        let addr: usize = (addr >> 2).try_into().unwrap();
 
         let mut pmpaddr: usize = 0;
         pmpaddr |= addr;
-        pmpaddr |= (size - 1) >> 3;
+        // verify the provided size is valid
+        assert!(((size - 1) >> 3) <= usize::MAX as Size);
+        pmpaddr |= ((size - 1) >> 3) as usize;
 
         return pmpaddr;
     }
 
     #[inline]
-    fn decode_napot(bits: usize) -> (usize, usize) {
+    fn decode_napot(bits: usize) -> (Addr, Size) {
         let mut pmpaddr: usize = bits;
         //TODO: this will lose the high two bits if it was a 34 bit address
         let address = pmpaddr;
 
         // find first zero in pmpaddr
         let mut range_mask = 1;
-        let mut size = 8;
+        let mut size: Size = 8;
         while pmpaddr.get_bit(0) != false {
             pmpaddr = pmpaddr >> 1;
             range_mask = (range_mask << 1) | 0x1;
             size = size << 1;
         }
 
-        let address = (address & !range_mask) << 2;
+        let address = ((address & !range_mask) as Addr) << 2;
         return (address, size);
     }
 }
@@ -79,7 +85,7 @@ macro_rules! reg {
     ) => {
         /// Physical memory protection address register
         pub mod $csr {
-            use super::PmpAddr;
+            use super::{Addr, PmpAddr, Size};
 
             read_csr!($addr);
             write_csr!($addr);
@@ -95,60 +101,60 @@ macro_rules! reg {
             }
 
             #[inline]
-            pub fn read_tor() -> usize {
+            pub fn read_tor() -> Addr {
                 // See riscv priv spec "Physical Memory Protection CSRs
                 // "Each PMP address register encodes bits 33–2 of a 34-bit physical address for RV32"
                 // and
                 // "For RV64, each PMP address register encodes bits 55–2 of a 56-bit physical address"
                 unsafe {
-                    return _read() << 2;
+                    return (_read() as Addr) << 2;
                 }
             }
             #[inline]
-            pub unsafe fn write_tor(addr: usize) {
+            pub unsafe fn write_tor(addr: Addr) {
                 // See riscv priv spec "Physical Memory Protection CSRs
                 // "Each PMP address register encodes bits 33–2 of a 34-bit physical address for RV32"
                 // and
                 // "For RV64, each PMP address register encodes bits 55–2 of a 56-bit physical address"
                 let addr = addr >> 2;
-                _write(addr);
+                _write(addr.try_into().unwrap());
             }
 
             #[inline]
-            pub fn read_na4() -> usize {
+            pub fn read_na4() -> Addr {
                 // See riscv priv spec "Physical Memory Protection CSRs
                 // "Each PMP address register encodes bits 33–2 of a 34-bit physical address for RV32"
                 // and
                 // "For RV64, each PMP address register encodes bits 55–2 of a 56-bit physical address"
                 unsafe {
-                    return _read() << 2;
+                    return (_read() as Addr) << 2;
                 }
             }
             #[inline]
-            pub unsafe fn write_na4(addr: usize) {
+            pub unsafe fn write_na4(addr: Addr) {
                 // See riscv priv spec "Physical Memory Protection CSRs
                 // "Each PMP address register encodes bits 33–2 of a 34-bit physical address for RV32"
                 // and
                 // "For RV64, each PMP address register encodes bits 55–2 of a 56-bit physical address"
                 let addr = addr >> 2;
-                _write(addr);
+                _write(addr.try_into().unwrap());
             }
 
             #[inline]
-            pub unsafe fn write_napot(addr: usize, size: usize) {
+            pub unsafe fn write_napot(addr: Addr, size: Size) {
                 _write(PmpAddr::encode_napot(addr, size));
             }
 
             #[inline]
-            pub fn read_napot() -> (usize, usize) {
+            pub fn read_napot() -> (Addr, Size) {
                 unsafe { PmpAddr::decode_napot(_read()) }
             }
         }
     };
 }
 
-pub unsafe fn write_tor_indexed(index: usize, addr: usize) {
-    assert!(index <= 64);
+pub unsafe fn write_tor_indexed(index: usize, addr: Addr) {
+    assert!(index < 64);
 
     match index {
         0 => pmpaddr0::write_tor(addr),
@@ -219,8 +225,8 @@ pub unsafe fn write_tor_indexed(index: usize, addr: usize) {
     }
 }
 
-pub unsafe fn write_napot_indexed(index: usize, addr: usize, size: usize) {
-    assert!(index <= 64);
+pub unsafe fn write_napot_indexed(index: usize, addr: Addr, size: Size) {
+    assert!(index < 64);
 
     match index {
         0 => pmpaddr0::write_napot(addr, size),
@@ -291,7 +297,7 @@ pub unsafe fn write_napot_indexed(index: usize, addr: usize, size: usize) {
     }
 }
 
-pub unsafe fn write_na4_indexed(index: usize, addr: usize, size: usize) {
+pub unsafe fn write_na4_indexed(index: usize, addr: Addr, size: Size) {
     write_napot_indexed(index, addr, size);
 }
 

--- a/src/register/pmpaddrx.rs
+++ b/src/register/pmpaddrx.rs
@@ -18,7 +18,7 @@ impl PmpAddr {
         match mode {
             Mode::OFF => (big_bits, None),
             Mode::TOR => (big_bits << 2, None),
-            Mode::NA4 => (big_bits << 2, None),
+            Mode::NA4 => (big_bits << 2, Some(4.try_into().unwrap())),
             Mode::NAPOT => {
                 let (addr, size) = Self::decode_napot(self.bits);
                 (addr, Some(size.try_into().unwrap()))


### PR DESCRIPTION
This is needed to support 2 seperate cases.  The first is a TOR region that ends at the end address space, and the second being a NAPOT region that is >= the address space size.

See https://github.com/rivosinc/hubris/pull/99 and https://github.com/rivosinc/humility/pull/33 for this changes being applied to some downstream projects. 