### PR TITLE
registers: pmpaddrx, pmpcfgx: derive `PartialEq` and `Eq`

### DIFF
--- a/src/register/pmpaddrx.rs
+++ b/src/register/pmpaddrx.rs
@@ -2,7 +2,7 @@ use crate::register::pmpcfgx::Mode;
 use bit_field::BitField;
 use core::num::NonZeroU64;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Eq, Debug)]
 pub struct PmpAddr {
     bits: usize,
 }

--- a/src/register/pmpcfgx.rs
+++ b/src/register/pmpcfgx.rs
@@ -5,7 +5,7 @@ use core::convert::From;
 
 /// Permission enum contains all possible permission modes for pmp registers
 /// NOTE: All encodings where R = 0 and W = 1 are reserved
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Permission {
     NONE = 0b000,
     R = 0b001,
@@ -18,7 +18,7 @@ pub enum Permission {
 }
 
 /// Mode enum contains all possible addressing modes for pmp registers
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Mode {
     OFF = 0b00,
     TOR = 0b01,
@@ -27,7 +27,7 @@ pub enum Mode {
 }
 
 /// PmpCfg struct holds a high-level representation of a single pmp configuration
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub struct PmpCfg {
     pub byte: u8,
 }


### PR DESCRIPTION
By deriving `PartialEq` and `Eq` the `PmpCfg`, `PmpAddr`, etc can be checked for equality by using `==`.