### PR TITLE
registers: pmpaddrx: fix alignment check

### DIFF
--- a/src/register/pmpaddrx.rs
+++ b/src/register/pmpaddrx.rs
@@ -61,7 +61,7 @@ impl PmpAddr {
             // check size is a power of 2
             ((size & (size-1)) != 0) ||
             // checks that the low bits where size is placed, are already zero
-            (addr & encoded_size != 0)
+            ((addr >> 2) & (encoded_size << 1) + 1 != 0)
         {
             return Err(());
         }


### PR DESCRIPTION
The low bits of the pmpaddrx CSR are used to encode the size, so we need to ensure the corresponding bits of the address are zero.  However, the pmpaddrx csr holds the high 32bits of a 34bit address, so the address needs to be shifted before performing this check.

I really botched this function the first time around, so now might be a good time to review the rest of the `encode_napot` function again...